### PR TITLE
Use globally configured tileUrl for CQ map

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -41,7 +41,7 @@ function load_was_map() {
 
 <?php if ($this->uri->segment(1) == "awards" && ($this->uri->segment(2) == "cq") ) { ?>
     <script src="<?php echo base_url(); ?>assets/js/Polyline.encoded.js"></script>
-    <script type="text/javascript" src="<?php echo base_url(); ?>assets/js/sections/cqmap.js"></script>
+    <script id="cqmapjs" type="text/javascript" src="<?php echo base_url(); ?>assets/js/sections/cqmap.js" tileUrl="<?php echo $this->optionslib->get_option('option_map_tile_server');?>"></script>
 <?php } ?>
 
 <?php if ($this->uri->segment(1) == "statistics") { ?>

--- a/assets/js/sections/cqmap.js
+++ b/assets/js/sections/cqmap.js
@@ -1,3 +1,5 @@
+var osmUrl = $('#cqmapjs').attr("tileUrl");
+
 function load_cq_map() {
     $('.nav-tabs a[href="#cqmap"]').tab('show');
     $.ajax({
@@ -117,7 +119,7 @@ function load_cq_map2(data) {
 
     var map = L.map('cqmap');
     L.tileLayer(
-        'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        osmUrl,
         {
             attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
             maxZoom: 18


### PR DESCRIPTION
This fixes the HTTP/HTTPS issue mentioned in my review in https://github.com/magicbug/Cloudlog/pull/1658.