### PR TITLE
Remove unneeded polygon and make lines thinner

### DIFF
--- a/assets/js/sections/cqmap.js
+++ b/assets/js/sections/cqmap.js
@@ -131,7 +131,6 @@ function load_cq_map2(data) {
     var workednotconfirmed = 0;
 
   for (var i = 0; i < cqzones.length; i++) {
-        L.Polyline.fromEncoded(cqzones[i]).addTo(map);
         var mapColor = 'red';
 
         if (data[i] == 'C') {
@@ -146,7 +145,7 @@ function load_cq_map2(data) {
         }
 
         L.Polygon.fromEncoded(cqzones[i], {
-                weight: 3,
+                weight: 2,
                 color: mapColor,
                 strokeOpacity: 0.3,
                 strokeWeight: 2,


### PR DESCRIPTION
Here is the patch re border thickness. If you just decrease the weight in line 149 you will see that there are blue colored polylines below. Not sure what those are for? I remove them because otherwise they would underly the thinner red/green/yellow borders and make all look a little blue-ly. Maybe it was a fargotten debug part of the code anyway?