### PR TITLE
If no API key is supplied we should check for a valid session and otherwise just redirect to login.

### DIFF
--- a/application/controllers/Backup.php
+++ b/application/controllers/Backup.php
@@ -21,6 +21,11 @@ class Backup extends CI_Controller {
 
 	/* Gets all QSOs and Dumps them to logbook.adi */
 	public function adif($key = null){ 
+		if ($key == null) {
+			$this->load->model('user_model');
+			if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
+		}
+
 		$this->load->helper('file');
 		// Set memory limit to unlimited to allow heavy usage
 		ini_set('memory_limit', '-1');


### PR DESCRIPTION
Because otherwise we would show an ugly SQL error (in case someone calls the backup function without API kay and without a valid session to exist):

![Screenshot from 2023-05-02 08-00-56](https://user-images.githubusercontent.com/7112907/235591308-42d1f91f-8d8f-4678-bbe7-440a3edc8599.png)
