### PR TITLE
count rows returns 1 even with 0 as result ...

### DIFF
--- a/application/models/Setup_model.php
+++ b/application/models/Setup_model.php
@@ -3,32 +3,26 @@
 class Setup_model extends CI_Model {
 
 	function getCountryCount() {
-		$sql = 'select count(*) from dxcc_entities';
-        $query = $this->db->query($sql);
+		$sql = 'select count(*) as count from dxcc_entities';
+		$query = $this->db->query($sql);
 
-        $result = $query->result();
-
-		return count($result);
+		return $query->row()->count;
 	}
 
 	function getLogbookCount() {
 		$userid = xss_clean($this->session->userdata('user_id'));
-		$sql = 'select count(*) from station_logbooks where user_id =' . $userid;
-        $query = $this->db->query($sql);
+		$sql = 'select count(*) as count from station_logbooks where user_id =' . $userid;
+		$query = $this->db->query($sql);
 
-        $result = $query->result();
-
-		return count($result);
+		return $query->row()->count;
 	}
 
 	function getLocationCount() {
 		$userid = xss_clean($this->session->userdata('user_id'));
-		$sql = 'select count(*) from station_profile where user_id =' . $userid;
-        $query = $this->db->query($sql);
+		$sql = 'select count(*) as count from station_profile where user_id =' . $userid;
+		$query = $this->db->query($sql);
 
-        $result = $query->result();
-
-		return count($result);
+		return $query->row()->count;
 	}
 }
 


### PR DESCRIPTION
$sql = 'select count(*) from dxcc_entities';

and

return count($result);

always results in 1 as result because it obviously counts the number of rows returned and this is always 1 ...